### PR TITLE
Align session join payload with participant list

### DIFF
--- a/app/hooks/useSocket.ts
+++ b/app/hooks/useSocket.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { io, Socket } from 'socket.io-client';
 
 export interface SocketEventHandlers {
-  'session-joined': (data: { sessionId: string; participantId: string; participantName: string }) => void;
+  'session-joined': (data: { sessionId: string; participants: string[] }) => void;
   'session-left': (data: { sessionId: string; participantId: string }) => void;
   'participant-joined': (data: { participantId: string; participantName: string }) => void;
   'participant-left': (data: { participantId: string }) => void;

--- a/src/hooks/useReadingSession.ts
+++ b/src/hooks/useReadingSession.ts
@@ -126,23 +126,41 @@ export function useReadingSession({
 
   // Event handlers
   const handleSessionJoined: SocketEventHandlers['session-joined'] = useCallback((data) => {
-    if (data.sessionId === sessionId && data.participantId === participantId) {
-      setSessionState(prev => ({
+    if (data.sessionId !== sessionId) {
+      return;
+    }
+
+    setSessionState(prev => {
+      const participantsFromEvent = data.participants ?? [];
+      const updatedParticipants = Array.from(new Set([
+        ...participantsFromEvent,
+        participantId,
+      ]));
+
+      return {
         ...prev,
         isActive: true,
-        participants: [...prev.participants, participantId],
-      }));
-      setError(null);
-    }
+        participants: updatedParticipants,
+      };
+    });
+    setError(null);
   }, [sessionId, participantId]);
 
   const handleParticipantJoined: SocketEventHandlers['participant-joined'] = useCallback((data) => {
-    if (data.participantId !== participantId) {
-      setSessionState(prev => ({
+    if (data.participantId === participantId) {
+      return;
+    }
+
+    setSessionState(prev => {
+      if (prev.participants.includes(data.participantId)) {
+        return prev;
+      }
+
+      return {
         ...prev,
         participants: [...prev.participants, data.participantId],
-      }));
-    }
+      };
+    });
   }, [participantId]);
 
   const handleParticipantLeft: SocketEventHandlers['participant-left'] = useCallback((data) => {

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { io, Socket } from 'socket.io-client';
 
 export interface SocketEventHandlers {
-  'session-joined': (data: { sessionId: string; participantId: string; participantName: string }) => void;
+  'session-joined': (data: { sessionId: string; participants: string[] }) => void;
   'session-left': (data: { sessionId: string; participantId: string }) => void;
   'participant-joined': (data: { participantId: string; participantName: string }) => void;
   'participant-left': (data: { participantId: string }) => void;


### PR DESCRIPTION
## Summary
- update the socket session-joined event typing to describe the participants array payload
- sync the reading session join handler with the new payload so the active state and participant list reflect the event data without duplicates
- mirror the socket and reading session updates in the app hooks to keep both entrypoints aligned

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd43977370832798e5f4881a6e882d